### PR TITLE
Modify admonitions (mkdocs) for special directives

### DIFF
--- a/docs/EN/operate/temptarget.md
+++ b/docs/EN/operate/temptarget.md
@@ -2,10 +2,10 @@
 
 ## Exercise
 
-!!! abstract "Highlights"
-    - Pack a snack when you plan to exercise
-    - Set a high temptarget 1-2 hours before your exercise
-    - Enable exercise related settings in preferences to reduce insulin delivered while exercising
+.. note::
+   - Pack a snack when you plan to exercise
+   - Set a high temptarget 1-2 hours before your exercise
+   - Enable exercise related settings in preferences to reduce insulin delivered while exercising
 
 Exercise can have immediate and long term effects on glycemic control. Generally individuals will find their blood sugar drops during intense exercise, and continues to drop for 3-4 hours after. They may also experience increased insulin sensitivity for 24 hours after exercise.
 
@@ -15,8 +15,8 @@ iAPS has some quality of life features that can make exercise easier to do while
 
 ## Pre-Meal
 
-!!! abstract "Highlights"
-    - Set a low temptarget 1-2 hours before meals to help with spikes
-    - Enable "Low Temptarget Lowers Sensitivity" to allow for greater insulin delivery
+.. note::
+   - Set a low temptarget 1-2 hours before meals to help with spikes
+   - Enable "Low Temptarget Lowers Sensitivity" to allow for greater insulin delivery
 
 If you plan to eat soon, you may want iAPS to provide you extra room to fill up on carbs. One way you can do this is by setting a temptarget approximately 1 mmol/L below your target, 1-2 hours prior to meals. You can also enable ["Low Temptarget Lowers Sensitivity"](../settings/configuration/preferences/targetsettings.md)  to give yourself more insulin for the upcoming meal and to bring your blood sugar down faster to the pre-meal range.

--- a/docs/EN/operate/troubleshoot.md
+++ b/docs/EN/operate/troubleshoot.md
@@ -3,8 +3,8 @@
 
 ## Morning IOB
 
-!!! abstract "Highlights"
-    - Check your morning IOB: if it is positive, increase your basal rates, if it is negative, decrease your basal rates.
+.. note::
+  - Check your morning IOB: if it is positive, increase your basal rates, if it is negative, decrease your basal rates.
 
 One of the easiest ways of optimizing your basal rates is by checking your IOB when you wake up in the morning. iAPS uses your basal profile as its net zero. If iAPS needs to give you more insulin overnight than your set basal rates, your IOB will be positive. Likewise, if you need less insulin overnight than your current basal rates, it will be negative. You can adjust your basal profile by 10%, and reassess the impact the following morning. Below are some nightscout images showing the impact of changing basal rates on IOB. You can also view your IOB on iAPS itself.
 
@@ -17,9 +17,9 @@ Note that iAPS does adjust your basal profile with autotune, but this system is 
 
 ## Site Change or Failure
 
-!!! abstract "Highlights"
-    - Pump changes can temporarily impact control. 
-    - Pump failures can negatively impact control for hours. Turn off closed loop when failure is discovered, and only turn back on when a new pump is installed.
+.. note::
+   - Pump changes can temporarily impact control. 
+   - Pump failures can negatively impact control for hours. Turn off closed loop when failure is discovered, and only turn back on when a new pump is installed.
 
 Pump site changes can negatively impact your immediate glycemic control. Different delivery sites vary in their ability to absorb insulin, impacting your perceived insulin sensitivity. iAPS should be able to accommodate to this change by resetting its Autosens meaurements [(assuming "Rewind Resets Autosens" is on)](../settings/configuration/preferences/othersettings.md) and adapting as needed.
 
@@ -29,9 +29,9 @@ When you find out your pump has failed, immediately turn off closed loop to prev
 
 ## Low Treatment
 
-!!! abstract "Highlights"
-    - Enter carbs for treatment into iAPS but do not bolus for it
-    - Consider reducing your profile ISF or Adjustment Factor if Dynamic ISF is enabled.
+.. note::
+   - Enter carbs for treatment into iAPS but do not bolus for it
+   - Consider reducing your profile ISF or Adjustment Factor if Dynamic ISF is enabled.
 
 Low blood sugar events can happen from time to time, but you will typically not require as much carbs to treat your lows as opposed to MDI or using a pump. When you treat a low, you should still enter the carbs consumed into the iAPS system so its autotune functionality can make better choices on your ICR, ISF and basal rates.
 


### PR DESCRIPTION
Attempt to modify the admonition style of markup used by "material-theme for mkdocs" to the special directives found in "ReadTheDocs" documentation. Not sure if this will work.

Link: https://rtd.xfel.eu/docs/how-to-read-the-docs/en/latest/how_to_document.html#special-directives