### PR TITLE
citations.md: update Discord link

### DIFF
--- a/docs/EN/resources/citations.md
+++ b/docs/EN/resources/citations.md
@@ -10,11 +10,11 @@ AndroidAPS implements the same OpenAPS algorithm with dynamic enhancements and m
 iAPS is a fork of Loop. While their underlying algorithms are different, they share some parts of their code base. Its recommended you take a quick glance in the [Loop Docs](https://loopkit.github.io/loopdocs/) for your issue, especially if it relates to pump usage and build errors. Many of these documents have been adapted from Loopdocs.
 
 ## Community Support
-There are many help groups surrounding iAPS. It is likely someone else has has your issue in the past. Please visit the [Discord](https://discord.gg/3eGsdykA6) and [Facebook](https://www.facebook.com/groups/1351938092206709) channels and review previous chat logs to find a solution. If you are a BC Diabetes Looper, please request a link to their Slack group from your case manager.
+There are many help groups surrounding iAPS. It is likely someone else has has your issue in the past. Please visit the [Discord](https://discord.gg/2gBpxRT2g) and [Facebook](https://www.facebook.com/groups/1351938092206709) channels and review previous chat logs to find a solution. If you are a BC Diabetes Looper, please request a link to their Slack group from your case manager.
 
 ## Citations
 - <a href="https://loopkit.github.io/loopdocs/">Loop Documentation</a>
 - <a href="https://loopkit.github.io/looptips/">Loop Tips</a>
 - <a href="https://openaps.readthedocs.io/">OpenAPS Documentation</a>
 - <a href="https://androidaps.readthedocs.io/">AndroidAPS Documentation</a>
-- Support groups on <a href="https://discord.gg/3eGsdykA">Discord</a>, <a href="https://www.facebook.com/groups/1351938092206709">Facebook</a>, and Slack
+- Support groups on <a href="https://discord.gg/2gBpxRT2g">Discord</a>, <a href="https://www.facebook.com/groups/1351938092206709">Facebook</a>, and Slack

--- a/docs/EN/resources/citations.md
+++ b/docs/EN/resources/citations.md
@@ -10,11 +10,11 @@ AndroidAPS implements the same OpenAPS algorithm with dynamic enhancements and m
 iAPS is a fork of Loop. While their underlying algorithms are different, they share some parts of their code base. Its recommended you take a quick glance in the [Loop Docs](https://loopkit.github.io/loopdocs/) for your issue, especially if it relates to pump usage and build errors. Many of these documents have been adapted from Loopdocs.
 
 ## Community Support
-There are many help groups surrounding iAPS. It is likely someone else has has your issue in the past. Please visit the [Discord](https://discord.gg/xfnxYaBG) and [Facebook](https://www.facebook.com/groups/1351938092206709) channels and review previous chat logs to find a solution. If you are a BC Diabetes Looper, please request a link to their Slack group from your case manager.
+There are many help groups surrounding iAPS. It is likely someone else has has your issue in the past. Please visit the [Discord](https://discord.gg/3eGsdykA6) and [Facebook](https://www.facebook.com/groups/1351938092206709) channels and review previous chat logs to find a solution. If you are a BC Diabetes Looper, please request a link to their Slack group from your case manager.
 
 ## Citations
 - <a href="https://loopkit.github.io/loopdocs/">Loop Documentation</a>
 - <a href="https://loopkit.github.io/looptips/">Loop Tips</a>
 - <a href="https://openaps.readthedocs.io/">OpenAPS Documentation</a>
 - <a href="https://androidaps.readthedocs.io/">AndroidAPS Documentation</a>
-- Support groups on <a href="https://discord.gg/xfnxYaBG">Discord</a>, <a href="https://www.facebook.com/groups/1351938092206709">Facebook</a>, and Slack
+- Support groups on <a href="https://discord.gg/3eGsdykA">Discord</a>, <a href="https://www.facebook.com/groups/1351938092206709">Facebook</a>, and Slack


### PR DESCRIPTION
The previous link was expired or invalid.